### PR TITLE
make Pdf Viewer behave like Android 5.0 "Document Task"

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,17 +1,49 @@
 apply plugin: 'com.android.application'
 
+/* gets the version name from the latest Git tag */
+def getGitVersionName = { ->
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'describe', '--tags', '--always'
+        standardOutput = stdout
+    }
+    return stdout.toString().trim()
+}
+
 android {
     compileSdkVersion 25
     buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "org.ninthfloor.copperpdf"
+        versionName getGitVersionName()
     }
 
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+        debug {
+            applicationIdSuffix ".debug"
+        }
+    }
+
+    /* set the debug versionCode based on how many commits in the repo */
+    applicationVariants.all { variant ->
+        if (variant.buildType.isDebuggable()) {
+            // default to a timestamp, in case anything fails later
+            variant.mergedFlavor.versionCode = new Date().getTime() / 1000
+            try {
+                def stdout = new ByteArrayOutputStream()
+                exec {
+                    commandLine 'git', 'rev-list', '--first-parent', '--count', 'HEAD'
+                    standardOutput = stdout
+                }
+                variant.mergedFlavor.versionCode = Integer.parseInt(stdout.toString().trim())
+            }
+            catch (ignored) {
+            }
         }
     }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,8 @@
             android:label="@string/app_name"
             android:theme="@style/AppTheme" >
         <activity android:name="co.copperhead.pdfviewer.PdfViewer"
-                android:label="@string/app_name" >
+                  android:documentLaunchMode="intoExisting"
+                android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/java/co/copperhead/pdfviewer/PdfViewer.java
+++ b/app/src/main/java/co/copperhead/pdfviewer/PdfViewer.java
@@ -90,8 +90,14 @@ public class PdfViewer extends Activity {
         String type = intent.getType();
 
         if (Intent.ACTION_VIEW.equals(action)) {
-            if (!type.equals("application/pdf")) {
-                throw new RuntimeException();
+            if (!"application/pdf".equals(type)) {
+                String appName = getString(R.string.app_name);
+                Toast.makeText(this,
+                        appName + ": unsupported file type: " + intent.getType(),
+                        Toast.LENGTH_SHORT).show();
+                setResult(RESULT_CANCELED);
+                finish();
+                return;
             }
             mUri = (Uri) intent.getData();
             mChannel.mPage = 1;

--- a/app/src/main/java/co/copperhead/pdfviewer/PdfViewer.java
+++ b/app/src/main/java/co/copperhead/pdfviewer/PdfViewer.java
@@ -7,11 +7,13 @@ import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.Gravity;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.view.WindowManager;
 import android.webkit.JavascriptInterface;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
@@ -65,6 +67,8 @@ public class PdfViewer extends Activity {
     @SuppressLint("SetJavaScriptEnabled")
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        getWindow().addFlags(WindowManager.LayoutParams.FLAG_SECURE);
 
         setContentView(R.layout.webview);
         ActionBar actionBar = getActionBar();
@@ -136,7 +140,11 @@ public class PdfViewer extends Activity {
                 @Override
                 public void run() {
                     mWebView.loadUrl("about:blank");
-                    finish();
+                    if (Build.VERSION.SDK_INT < 21) {
+                        finish();
+                    } else {
+                        finishAndRemoveTask();
+                    }
                 }
             });
         }

--- a/app/src/main/java/co/copperhead/pdfviewer/PdfViewer.java
+++ b/app/src/main/java/co/copperhead/pdfviewer/PdfViewer.java
@@ -3,12 +3,18 @@ package co.copperhead.pdfviewer;
 import android.annotation.SuppressLint;
 import android.app.ActionBar;
 import android.app.Activity;
+import android.app.ActivityManager;
 import android.app.AlertDialog;
+import android.content.ContentResolver;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.database.Cursor;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.provider.MediaStore;
+import android.provider.OpenableColumns;
+import android.text.TextUtils;
 import android.view.Gravity;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -125,6 +131,29 @@ public class PdfViewer extends Activity {
 
     private void loadPdf() {
         mWebView.evaluateJavascript("onGetDocument()", null);
+
+        ContentResolver contentResolver = getContentResolver();
+        Cursor cursor = contentResolver.query(mUri, null, null, null, null);
+        String[] projection = new String[]{
+                OpenableColumns.DISPLAY_NAME,
+                MediaStore.MediaColumns.TITLE,
+        };
+        if (cursor != null) {
+            if (cursor.moveToNext()) {
+                for (String check : projection) {
+                    int index = cursor.getColumnIndex(check);
+                    if (index > -1) {
+                        String name = cursor.getString(index);
+                        if (!TextUtils.isEmpty(name)) {
+                            setTitle(name);
+                            setTaskDescription(new ActivityManager.TaskDescription(name));
+                            break;
+                        }
+                    }
+                }
+            }
+            cursor.close();
+        }
     }
 
     private void openDocument() {

--- a/app/src/main/java/co/copperhead/pdfviewer/PdfViewer.java
+++ b/app/src/main/java/co/copperhead/pdfviewer/PdfViewer.java
@@ -6,6 +6,7 @@ import android.app.Activity;
 import android.app.ActivityManager;
 import android.app.AlertDialog;
 import android.content.ContentResolver;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
@@ -19,7 +20,9 @@ import android.view.Gravity;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.view.View;
 import android.view.WindowManager;
+import android.view.inputmethod.InputMethodManager;
 import android.webkit.JavascriptInterface;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
@@ -101,6 +104,14 @@ public class PdfViewer extends Activity {
                 }
             }
         });
+
+        // some apps launch the PDF document, but leave the keyboard open, so hide it
+        View view = this.getCurrentFocus();
+        if (view == null) {
+            view = findViewById(android.R.id.content).getRootView();
+        }
+        InputMethodManager imm = (InputMethodManager)getSystemService(Context.INPUT_METHOD_SERVICE);
+        imm.hideSoftInputFromWindow(view.getWindowToken(), 0);
 
         Intent intent = getIntent();
         String action = intent.getAction();

--- a/app/src/main/java/co/copperhead/pdfviewer/PdfViewer.java
+++ b/app/src/main/java/co/copperhead/pdfviewer/PdfViewer.java
@@ -1,8 +1,9 @@
 package co.copperhead.pdfviewer;
 
+import android.annotation.SuppressLint;
+import android.app.ActionBar;
 import android.app.Activity;
 import android.app.AlertDialog;
-import android.annotation.SuppressLint;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.Uri;
@@ -17,6 +18,7 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.FrameLayout;
 import android.widget.NumberPicker;
+import android.widget.Toast;
 
 public class PdfViewer extends Activity {
     private static final int MAX_ZOOM_LEVEL = 4;
@@ -65,6 +67,11 @@ public class PdfViewer extends Activity {
         super.onCreate(savedInstanceState);
 
         setContentView(R.layout.webview);
+        ActionBar actionBar = getActionBar();
+        if (actionBar != null) {
+            actionBar.setDisplayHomeAsUpEnabled(true);
+            actionBar.setHomeActionContentDescription(R.string.action_close);
+        }
 
         mWebView = (WebView) findViewById(R.id.webView1);
         WebSettings settings = mWebView.getSettings();
@@ -123,6 +130,18 @@ public class PdfViewer extends Activity {
         startActivityForResult(intent, ACTION_OPEN_DOCUMENT_REQUEST_CODE);
     }
 
+    private void closeDocument() {
+        if (mWebView != null) {
+            runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    mWebView.loadUrl("about:blank");
+                    finish();
+                }
+            });
+        }
+    }
+
     @Override
     public void onSaveInstanceState(Bundle savedInstanceState) {
         super.onSaveInstanceState(savedInstanceState);
@@ -170,6 +189,11 @@ public class PdfViewer extends Activity {
             case R.id.action_open:
                 openDocument();
                 return super.onOptionsItemSelected(item);
+
+            case android.R.id.home:
+            case R.id.action_close:
+                closeDocument();
+                return true;
 
             case R.id.action_zoom_out:
                 if (mChannel.mZoomLevel > 0) {

--- a/app/src/main/res/menu/pdf_viewer.xml
+++ b/app/src/main/res/menu/pdf_viewer.xml
@@ -19,10 +19,16 @@
         android:showAsAction="ifRoom" />
 
     <item
-        android:id="@+id/action_open"
-        android:icon="@drawable/ic_insert_drive_file_white_24dp"
-        android:title="@string/action_open"
-        android:showAsAction="ifRoom" />
+            android:id="@+id/action_open"
+            android:icon="@drawable/ic_insert_drive_file_white_24dp"
+            android:title="@string/action_open"
+            android:showAsAction="ifRoom" />
+
+    <item
+            android:id="@+id/action_close"
+            android:icon="@android:drawable/ic_menu_close_clear_cancel"
+            android:title="@string/action_close"
+            android:showAsAction="ifRoom" />
 
     <item
         android:id="@+id/action_zoom_out"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="action_previous">Next page</string>
     <string name="action_next">Previous page</string>
     <string name="action_open">Open document</string>
+    <string name="action_close">Close document</string>
     <string name="action_zoom_out">Zoom out</string>
     <string name="action_zoom_in">Zoom in</string>
     <string name="action_jump_to_page">Jump to page</string>


### PR DESCRIPTION
Android 5.0 started making document viewer apps behave like multiple windows. This makes CuprumPDF act like that, with one window per document, and the title of that window being the document title.

This is based on my work that I did here, which I want to ensure remains free software:
https://github.com/CopperheadOS/platform_packages_apps_PdfViewer/pull/22