### PR TITLE
Don't show document-related menu items until document loaded

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
         android:versionCode="4"
         android:versionName="1.2.1" >
     <uses-sdk android:minSdkVersion="23"
-            android:targetSdkVersion="25" />
+            android:targetSdkVersion="26" />
     <application android:icon="@mipmap/ic_launcher"
             android:label="@string/app_name"
             android:theme="@style/AppTheme" >

--- a/app/src/main/assets/viewer.js
+++ b/app/src/main/assets/viewer.js
@@ -63,5 +63,6 @@ function onGetDocument() {
         channel.setNumPages(pdfDoc.numPages);
         scale = zoomLevels[channel.getZoomLevel()] / 100;
         renderPage(channel.getPage());
+        channel.onDocumentLoaded();
     });
 }

--- a/app/src/main/java/co/copperhead/pdfviewer/PdfViewer.java
+++ b/app/src/main/java/co/copperhead/pdfviewer/PdfViewer.java
@@ -44,6 +44,7 @@ public class PdfViewer extends Activity {
     private WebView mWebView;
     private Uri mUri;
     private Channel mChannel;
+    private boolean documentLoaded;
 
     private class Channel {
         private int mPage;
@@ -73,6 +74,9 @@ public class PdfViewer extends Activity {
         public void setNumPages(int numPages) {
             mNumPages = numPages;
         }
+
+        @JavascriptInterface
+        public void onDocumentLoaded() { documentLoaded = true; invalidateOptionsMenu(); }
     }
 
     @Override
@@ -184,6 +188,11 @@ public class PdfViewer extends Activity {
         startActivityForResult(intent, ACTION_OPEN_DOCUMENT_REQUEST_CODE);
     }
 
+    private void renderDocument() {
+        documentLoaded = false;
+        mWebView.evaluateJavascript("onRenderPage()", null);
+    }
+
     private void closeDocument() {
         if (mWebView != null) {
             runOnUiThread(new Runnable() {
@@ -224,6 +233,11 @@ public class PdfViewer extends Activity {
         super.onCreateOptionsMenu(menu);
         MenuInflater inflater = getMenuInflater();
         inflater.inflate(R.menu.pdf_viewer, menu);
+
+        if (documentLoaded) {
+            menu.findItem(R.id.action_print).setVisible(true);
+        }
+
         return true;
     }
 
@@ -233,14 +247,14 @@ public class PdfViewer extends Activity {
             case R.id.action_previous:
                 if (mChannel.mPage > 1) {
                     mChannel.mPage--;
-                    mWebView.evaluateJavascript("onRenderPage()", null);
+                    renderDocument();
                 }
                 return super.onOptionsItemSelected(item);
 
             case R.id.action_next:
                 if (mChannel.mPage < mChannel.mNumPages) {
                     mChannel.mPage++;
-                    mWebView.evaluateJavascript("onRenderPage()", null);
+                    renderDocument();
                 }
                 return super.onOptionsItemSelected(item);
 
@@ -256,14 +270,14 @@ public class PdfViewer extends Activity {
             case R.id.action_zoom_out:
                 if (mChannel.mZoomLevel > 0) {
                     mChannel.mZoomLevel--;
-                    mWebView.evaluateJavascript("onRenderPage()", null);
+                    renderDocument();
                 }
                 return super.onOptionsItemSelected(item);
 
             case R.id.action_zoom_in:
                 if (mChannel.mZoomLevel < MAX_ZOOM_LEVEL) {
                     mChannel.mZoomLevel++;
-                    mWebView.evaluateJavascript("onRenderPage()", null);
+                    renderDocument();
                 }
                 return super.onOptionsItemSelected(item);
 
@@ -287,7 +301,7 @@ public class PdfViewer extends Activity {
                             int page = picker.getValue();
                             if (page >= 1 && page <= mChannel.mNumPages) {
                                 mChannel.mPage = page;
-                                mWebView.evaluateJavascript("onRenderPage()", null);
+                                renderDocument();
                             }
                         }
                     })

--- a/app/src/main/java/co/copperhead/pdfviewer/PdfViewer.java
+++ b/app/src/main/java/co/copperhead/pdfviewer/PdfViewer.java
@@ -190,6 +190,7 @@ public class PdfViewer extends Activity {
 
     private void renderDocument() {
         documentLoaded = false;
+        invalidateOptionsMenu();
         mWebView.evaluateJavascript("onRenderPage()", null);
     }
 
@@ -235,7 +236,14 @@ public class PdfViewer extends Activity {
         inflater.inflate(R.menu.pdf_viewer, menu);
 
         if (documentLoaded) {
-            menu.findItem(R.id.action_print).setVisible(true);
+            for (int itemId : new int[] { R.id.action_previous,
+                                    R.id.action_next,
+                                    R.id.action_close,
+                                    R.id.action_zoom_out,
+                                    R.id.action_zoom_in,
+                                    R.id.action_print }) {
+                menu.findItem(itemId).setVisible(true);
+            }
         }
 
         return true;

--- a/app/src/main/res/menu/pdf_viewer.xml
+++ b/app/src/main/res/menu/pdf_viewer.xml
@@ -25,27 +25,31 @@
             android:showAsAction="ifRoom" />
 
     <item
-            android:id="@+id/action_close"
-            android:icon="@android:drawable/ic_menu_close_clear_cancel"
-            android:title="@string/action_close"
-            android:showAsAction="ifRoom" />
+        android:id="@+id/action_close"
+        android:icon="@android:drawable/ic_menu_close_clear_cancel"
+        android:title="@string/action_close"
+        android:visible="false"
+        android:showAsAction="ifRoom" />
 
     <item
         android:id="@+id/action_zoom_out"
         android:icon="@drawable/ic_zoom_out_white_24dp"
         android:title="@string/action_zoom_out"
+        android:visible="false"
         android:showAsAction="ifRoom" />
 
     <item
         android:id="@+id/action_zoom_in"
         android:icon="@drawable/ic_zoom_in_white_24dp"
         android:title="@string/action_zoom_in"
+        android:visible="false"
         android:showAsAction="ifRoom" />
 
     <item
         android:id="@+id/action_jump_to_page"
         android:icon="@drawable/ic_pageview_white_24dp"
         android:title="@string/action_jump_to_page"
+        android:visible="false"
         android:showAsAction="ifRoom" />
 
     <item

--- a/app/src/main/res/menu/pdf_viewer.xml
+++ b/app/src/main/res/menu/pdf_viewer.xml
@@ -52,6 +52,7 @@
         android:id="@+id/action_print"
         android:icon="@drawable/ic_print_white_24dp"
         android:title="@string/action_print"
+        android:visible="false"
         android:showAsAction="ifRoom" />
 
 </menu>

--- a/app/src/main/res/menu/pdf_viewer.xml
+++ b/app/src/main/res/menu/pdf_viewer.xml
@@ -10,19 +10,21 @@
         android:id="@+id/action_previous"
         android:icon="@drawable/ic_navigate_before_white_24dp"
         android:title="@string/action_previous"
+        android:visible="false"
         android:showAsAction="ifRoom" />
 
     <item
         android:id="@+id/action_next"
         android:icon="@drawable/ic_navigate_next_white_24dp"
         android:title="@string/action_next"
+        android:visible="false"
         android:showAsAction="ifRoom" />
 
     <item
-            android:id="@+id/action_open"
-            android:icon="@drawable/ic_insert_drive_file_white_24dp"
-            android:title="@string/action_open"
-            android:showAsAction="ifRoom" />
+        android:id="@+id/action_open"
+        android:icon="@drawable/ic_insert_drive_file_white_24dp"
+        android:title="@string/action_open"
+        android:showAsAction="ifRoom" />
 
     <item
         android:id="@+id/action_close"


### PR DESCRIPTION
As discussed with @Tommy-Geenexus in #7, this PR implements an onDocumentLoaded callback that enables document-related menu items such as printing.

One thing I'm not 100% happy with is that the callback is run a lot earlier than when the whole page is actually rendered. Maybe @Tommy-Geenexus can help?